### PR TITLE
split strings only in case of correct method

### DIFF
--- a/filter.go
+++ b/filter.go
@@ -169,7 +169,7 @@ func (f *Filter) parseValue(valueType string, value string, delimiter string) er
 
 	var list []string
 
-	if strings.Contains(value, delimiter) {
+	if strings.Contains(value, delimiter) && (f.Method == IN || f.Method == NIN) {
 		list = strings.Split(value, delimiter)
 	} else {
 		list = append(list, value)


### PR DESCRIPTION
Lets assume the following: You want to perform an LIKE-Query and your string contains a comma, for example `title[like]=to be, or%`. The query parser then treats the input as a list because a comma is defined as `delimiterIN`. This results in a skipped filter because a list is only allowed with `IN` or `NIN`, so queries that contain a comma are thrown away.

I added a little check if the user really wants to do some delimiting. If thats not the case the input string is treated as a regular string.

PS: thanks so much for your work here! This is a perfect solution to my problem! Greetings from Lübeck